### PR TITLE
Update search method in menus

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     },
     "license": "ISC",
     "devDependencies": {
+        "@aidenlx/chs-patch": "^1.3.1",
         "@rollup/plugin-typescript": "^8",
         "i18next": "^20.3.2",
         "monkey-around": "^2.1",


### PR DESCRIPTION
1. Utilize obsidian's built-in fuzzy search method, used in quick switcher
2. With [cm-chs-patch v1.3.1+](https://github.com/aidenlx/cm-chs-patch) installed, the search method will use Chinese parse API to convert Chinese into Pinyin, which can be searched by key strokes