### PR TITLE
Use frontmatter properties as note titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ And an extensive set of keyboard operations is available as well:
 
 Like the built-in file explorer, Quick Explorer will either show all files, or only the ones supported by Obsidian, depending upon whether the "Detect all file extensions" setting is enabled in the "Files and Links" options tab.
 
+The **Note title property** setting can use a frontmatter property (for example, `title`) as the display name for Markdown notes in Quick Explorer lists. A note falls back to its file name when the configured property is missing or empty. Notes are sorted and searchable by the displayed name.
+
 Quick explorer also includes six hotkeyable commands:
 
 * **Browse vault**, which opens the dropdown for the vault root, and
@@ -79,8 +81,7 @@ Another compatibility issue: some themes attempt to hide or downplay title bar i
 
 ### Current Limitations
 
-* Files are always sorted in ascending name order (using the same collation rules as the file-explorer view)
+* Files are always sorted in ascending display-name order (using the same collation rules as the file-explorer view)
 * You can drag things *out of* the dropdowns, but you can't drop anything *into* them
 * There is no way to configure sorting or grouping of files
 * Only "inside same"-style folder notes are supported
-

--- a/src/FolderMenu.ts
+++ b/src/FolderMenu.ts
@@ -4,7 +4,7 @@ import { PopupMenu, MenuParent, SearchableMenuItem } from "./menus.ts";
 import { ContextMenu } from "./ContextMenu.ts";
 import { around } from "monkey-around";
 import { onElement, windowForDom, the } from "@ophidian/core";
-import { fileIcon, folderNoteFor, previewIcons, sortedFiles } from "./file-info.ts";
+import { displayName, fileIcon, folderNoteFor, previewIcons, sortedFiles } from "./file-info.ts";
 import QE from "./quick-explorer.tsx";
 import * as o from "obsidian"
 
@@ -49,6 +49,7 @@ let autoPreview = true
 export class FolderMenu extends PopupMenu implements HoverParent {
 
     parentFolder: TFolder = this.parent instanceof FolderMenu ? this.parent.folder : null;
+    get noteTitleProperty() { return the(QE).settings.noteTitleProperty; }
 
     constructor(public parent: MenuParent, public folder: TFolder, public selectedFile?: TAbstractFile, public crumb?: Breadcrumb) {
         super(parent);
@@ -236,7 +237,7 @@ export class FolderMenu extends PopupMenu implements HoverParent {
 
     loadFiles(folder: TFolder, selectedFile?: TAbstractFile) {
         this.items.forEach(i => i.dom.detach()); this.items = [];
-        const {folderNote, folders, files} = sortedFiles(folder);
+        const {folderNote, folders, files} = sortedFiles(folder, undefined, this.noteTitleProperty);
         if (folderNote) {
             this.addFile(folderNote);
         }
@@ -258,13 +259,12 @@ export class FolderMenu extends PopupMenu implements HoverParent {
     addFile(file: TFile|TFolder) {
         const icon = fileIcon(file);
         this.addItem(i => {
-            i.setTitle(file.name);
+            i.setTitle(displayName(file, this.noteTitleProperty));
             i.dom.dataset.filePath = file.path;
             i.dom.setAttr("draggable", "true");
             i.dom.addClass (file instanceof TFolder ? "is-qe-folder" : "is-qe-file");
             if (icon) i.setIcon(icon);
             if (file instanceof TFile) {
-                i.setTitle(file.basename);
                 if (file.extension !== "md") i.dom.createDiv({text: file.extension, cls: ["nav-file-tag","qe-extension"]});
             } else if (file !== this.folder.parent) {
                 const count = this.fileCount(file);
@@ -318,6 +318,9 @@ export class FolderMenu extends PopupMenu implements HoverParent {
             }
         }));
         this.registerEvent(this.app.vault.on("delete", file => this.removeItemForPath(file.path)));
+        this.registerEvent(this.app.metadataCache.on("changed", file => {
+            if (this.noteTitleProperty && this.folder === file.parent) this.refreshFiles();
+        }));
 
         // Activate preview immediately if applicable
         if (autoPreview && this.selected != -1) this.showPopover();

--- a/src/file-info.ts
+++ b/src/file-info.ts
@@ -1,4 +1,4 @@
-import { TAbstractFile, TFile, TFolder } from "./obsidian.ts";
+import { parseFrontMatterEntry, TAbstractFile, TFile, TFolder } from "./obsidian.ts";
 import { app } from "@ophidian/core";
 
 export const previewIcons: Record<string, string> = {
@@ -32,27 +32,55 @@ export function folderNotePath(folder: TFolder) {
 
 const alphaSort = new Intl.Collator(undefined, {usage: "sort", sensitivity: "base", numeric: true})["compare"];
 
-export function sortedFiles(folder: TFolder, allFiles: boolean = app.vault.getConfig("showUnsupportedFiles")) {
+export function displayName(file: TFile|TFolder, noteTitleProperty = "") {
+    if (file instanceof TFolder) return file.name;
+
+    const fallback = file.basename;
+    if (file.extension !== "md" || !noteTitleProperty) return fallback;
+
+    const frontmatter = app.metadataCache.getFileCache(file)?.frontmatter;
+    const value = parseFrontMatterEntry(frontmatter, noteTitleProperty);
+    return propertyDisplayName(value) ?? fallback;
+}
+
+function propertyDisplayName(value: unknown): string | undefined {
+    if (typeof value === "string") return value.trim() || undefined;
+    if (typeof value === "number" || typeof value === "boolean") return String(value);
+    if (Array.isArray(value)) {
+        const title = value
+            .filter(item => typeof item === "string" || typeof item === "number" || typeof item === "boolean")
+            .map(String)
+            .join(", ")
+            .trim();
+        return title || undefined;
+    }
+}
+
+export function sortedFiles(
+    folder: TFolder,
+    allFiles: boolean = app.vault.getConfig("showUnsupportedFiles"),
+    noteTitleProperty = "",
+) {
     const children = folder.children as Array<TFile|TFolder>;
     const folderNote = folderNoteFor(folder);
     const items = children.slice().sort((a: TAbstractFile, b: TAbstractFile) => alphaSort(a.name, b.name))
     const folders = items.filter(f => f instanceof TFolder) as TFolder[];
     const files   = items.filter(f => f instanceof TFile && f !== folderNote && (allFiles || fileIcon(f))) as TFile[];
     folders.sort((a, b) => alphaSort(a.name, b.name));
-    files.sort((a, b) => alphaSort(a.basename, b.basename));
+    files.sort((a, b) => alphaSort(displayName(a, noteTitleProperty), displayName(b, noteTitleProperty)));
     return {folderNote, folders, files};
 }
 
-function fileIndex(folder: TFolder, allFiles?: boolean): TAbstractFile[] {
-    const {folderNote, folders, files} = sortedFiles(folder, false);
+function fileIndex(folder: TFolder, noteTitleProperty = ""): TAbstractFile[] {
+    const {folderNote, folders, files} = sortedFiles(folder, false, noteTitleProperty);
     return ((folderNote ? [folderNote] : []) as TAbstractFile[]).concat(folders, files);
 }
 
-export function navigateFile(file: TAbstractFile, direction: number, relative: boolean): TFile {
+export function navigateFile(file: TAbstractFile, direction: number, relative: boolean, noteTitleProperty = ""): TFile {
     const seen = new Set<TAbstractFile>();
     while (file?.parent && !seen.has(file)) {
         seen.add(file);
-        let all = fileIndex(file.parent, false);
+        let all = fileIndex(file.parent, noteTitleProperty);
         let pos = all.indexOf(file);
         if (pos === -1) return; // XXX should never happen!
         if (relative) {
@@ -65,7 +93,7 @@ export function navigateFile(file: TAbstractFile, direction: number, relative: b
             file = all[pos];
             if (file instanceof TFile) return file;
             else if (file instanceof TFolder) {
-                all = fileIndex(file, false);
+                all = fileIndex(file, noteTitleProperty);
                 pos = direction > 0 ? 0 : all.length - 1;
             }
             else pos += direction; // XXX should never get here

--- a/src/quick-explorer.tsx
+++ b/src/quick-explorer.tsx
@@ -7,6 +7,7 @@ import "./styles.scss"
 import { navigateFile } from "./file-info.ts";
 import { ContextMenu } from "./ContextMenu.ts";
 import { around } from "monkey-around";
+import { DEFAULT_SETTINGS, normalizeSettings, QESettingTab, QESettings } from "./settings.ts";
 
 declare module "obsidian" {
     interface Workspace {
@@ -24,12 +25,16 @@ export default class QE extends Plugin {
     use = use.plugin(this);
     explorers = this.use(Explorer).watch();
     ss = this.use(StyleSettings);
+    settings: QESettings = {...DEFAULT_SETTINGS};
 
     updateCurrent(leaf = getActiveLeaf(this.app), file = this.app.workspace.getActiveFile()) {
         if (isLeafAttached(leaf)) this.explorers.forLeaf(leaf).update(file);
     }
 
-    onload() {
+    async onload() {
+        await this.loadSettings();
+        this.addSettingTab(new QESettingTab(this.app, this));
+
         this.app.workspace.registerHoverLinkSource(hoverSource, {
             display: 'Quick Explorer', defaultMod: true
         });
@@ -72,9 +77,18 @@ export default class QE extends Plugin {
     goFile(dir: number, relative: boolean) {
         return () => {
             const curFile = app.workspace.getActiveFile();
-            const goFile = curFile && navigateFile(curFile, dir, relative);
+            const goFile = curFile && navigateFile(curFile, dir, relative, this.settings.noteTitleProperty);
             if (goFile && goFile !== curFile) void app.workspace.getLeaf().openFile(goFile);
         }
+    }
+
+    async loadSettings() {
+        this.settings = normalizeSettings(await this.loadData());
+    }
+
+    async setNoteTitleProperty(value: string) {
+        this.settings.noteTitleProperty = value.trim();
+        await this.saveData(this.settings);
     }
 
     onunload() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,40 @@
+import { PluginSettingTab, Setting } from "./obsidian.ts";
+import type { App } from "./obsidian.ts";
+import type QE from "./quick-explorer.tsx";
+
+export interface QESettings {
+    noteTitleProperty: string
+}
+
+export const DEFAULT_SETTINGS: QESettings = {
+    noteTitleProperty: "",
+}
+
+export function normalizeSettings(data: unknown): QESettings {
+    const saved = data && typeof data === "object" ? data as Record<string, unknown> : {};
+
+    return {
+        noteTitleProperty: typeof saved.noteTitleProperty === "string"
+            ? saved.noteTitleProperty.trim()
+            : DEFAULT_SETTINGS.noteTitleProperty,
+    };
+}
+
+export class QESettingTab extends PluginSettingTab {
+    constructor(app: App, public plugin: QE) {
+        super(app, plugin);
+    }
+
+    display() {
+        this.containerEl.empty();
+
+        new Setting(this.containerEl)
+            .setName("Note title property")
+            .setDesc("Use this frontmatter property as the display name for Markdown notes in Quick Explorer lists. Notes without a non-empty value use their file name.")
+            .addText(text => text
+                .setPlaceholder("title")
+                .setValue(this.plugin.settings.noteTitleProperty)
+                .onChange(value => this.plugin.setNoteTitleProperty(value))
+            );
+    }
+}


### PR DESCRIPTION
I use a plugin that allows to put a note title to a frontmatter property like `title` - it allows to have some arbitrary non-ASCII characters in titles without sacrificing portability between platforms. But Quick Explorer did not support this and it showed only "raw" filenames. This change lets Quick Explorer show a title from frontmatter while keeping the underlying file path unchanged.

## What changed

A new **Note title property** setting accepts a property name such as `title`. When it is configured, Quick Explorer prefers that value for Markdown notes in its lists.

If the property is missing or empty, Quick Explorer simply falls back to the file basename. Folders and non-Markdown files keep their existing names. The displayed title is also used for sorting, searching, and keyboard navigation, and an open menu refreshes when the note's frontmatter changes.

The setting is empty by default, so nothing changes for existing users unless they opt in.